### PR TITLE
Fix an edge case with Jira

### DIFF
--- a/src/atlast-okta.user.js
+++ b/src/atlast-okta.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         At last! Okta! (Confluence and Jira Okta Redirect Fixer)
 // @namespace    https://github.com/IncPlusPlus/atlast-okta
-// @version      0.5
+// @version      0.6
 // @description  When Confluence or Jira's sessions expire, they require the user to log in again. However, our Okta configuration doesn't send the browser back to the original page that was being viewed. This userscript fixes that.
 // @author       IncPlusPlus
 // @include      https://confluence.*.tld/*

--- a/src/atlast-okta.user.js
+++ b/src/atlast-okta.user.js
@@ -30,6 +30,19 @@ const INTENDED_DESTINATION = 'incplusplus.atlast-okta.intended_destination';
 // Set when the user lands on a sign-on page. The value is set to the full hostname of the Jira or Confluence server.
 const INTENDED_HOSTNAME = 'incplusplus.atlast-okta.intended_hostname';
 
+/**
+ * Prepends a slash to a path string if necessary. Otherwise, returns the input string.
+ * @param pathString a path string that may or may not start with "/"
+ * @return the path, starting with a slash
+ */
+const prependSlash = (pathString) => {
+    if (pathString.startsWith('/')) {
+        return pathString;
+    } else {
+        return '/' + pathString;
+    }
+}
+
 const processJiraState = (location) => {
     if (location.toString().includes('/okta_login.jsp')) {
         const params = new URLSearchParams(location.search);
@@ -37,7 +50,7 @@ const processJiraState = (location) => {
         const intendedPagePath = params.get('RelayState');
         // If intendedPagePath is null, the RelayState query param is missing. Do nothing
         if (intendedPagePath) {
-            window.sessionStorage.setItem(INTENDED_DESTINATION, decodeURIComponent(intendedPagePath));
+            window.sessionStorage.setItem(INTENDED_DESTINATION, prependSlash(decodeURIComponent(intendedPagePath)));
             window.sessionStorage.setItem(INTENDED_HOSTNAME, location.origin);
         }
     } else {


### PR DESCRIPTION
Accounts for a case where Jira's RelayState won't begin with a slash. This happened to me a few minutes ago. Normally, users are redirected to the login page after their session expires. However, sometimes the page will instead show a prompt at the top right to log in again. It turns out that if you click that (at least if your current page is /secure/rapidboard.jspa?...), the RelayState's value won't begin with a slash character. I had been depending on the slash character always being present, but it seems that in this case, it is omitted.