### PR TITLE
Add @run-at document-start to improve load time

### DIFF
--- a/src/atlast-okta.user.js
+++ b/src/atlast-okta.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         At last! Okta! (Confluence and Jira Okta Redirect Fixer)
 // @namespace    https://github.com/IncPlusPlus/atlast-okta
-// @version      0.7
+// @version      0.8
 // @description  When Confluence or Jira's sessions expire, they require the user to log in again. However, our Okta configuration doesn't send the browser back to the original page that was being viewed. This userscript fixes that.
 // @author       IncPlusPlus
 // @include      https://confluence.*.tld/*

--- a/src/atlast-okta.user.js
+++ b/src/atlast-okta.user.js
@@ -7,6 +7,7 @@
 // @include      https://confluence.*.tld/*
 // @include      https://jira.*.tld/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=atlassian.com
+// @run-at       document-start
 // ==/UserScript==
 
 /*


### PR DESCRIPTION
Added [`@run-at document-start`](https://www.tampermonkey.net/documentation.php?locale=en#meta:run_at) to the metadata to improve load time. Before this, you'd have to wait for the Jira/Confluence landing page to load before you are taken where back to where you were (as the implicit default was [`@run-at document-end`](https://wiki.greasespot.net/Metadata_Block#@run-at). Now, you're redirected to where you want to go as soon as the browser reaches the landing page.

Closes #8