### PR TITLE
Add run-at document-start to improve load time

### DIFF
--- a/src/atlast-okta.user.js
+++ b/src/atlast-okta.user.js
@@ -7,6 +7,7 @@
 // @include      https://confluence.*.tld/*
 // @include      https://jira.*.tld/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=atlassian.com
+// @run-at       document-start
 // @downloadUrl  https://github.com/IncPlusPlus/atlast-okta/releases/latest/download/atlast-okta.user.js
 // @updateUrl    https://github.com/IncPlusPlus/atlast-okta/releases/latest/download/atlast-okta.meta.js
 // ==/UserScript==


### PR DESCRIPTION
Added @run-at document-start to the metadata to improve load time. Before this, you'd have to wait for the Jira/Confluence landing page to load before you are taken where back to where you were. Now, you're redirected to where you want to go as soon as the browser reaches the landing page.